### PR TITLE
Fix graceful shutdown deadlock

### DIFF
--- a/lywsd03mmc_passive_receiver.py
+++ b/lywsd03mmc_passive_receiver.py
@@ -495,9 +495,14 @@ def main() -> None:
     server.daemon_threads = True
     logging.info("HTTP API listening on http://%s:%d", args.host, args.port)
 
+    shutdown_initiated = threading.Event()
+
     def shutdown(signum: int, _frame) -> None:
+        if shutdown_initiated.is_set():
+            return
+        shutdown_initiated.set()
         logging.info("Received signal %s, shutting down", signum)
-        server.shutdown()
+        threading.Thread(target=server.shutdown, name="HTTPServerShutdown", daemon=True).start()
         scanner.stop()
 
     signal.signal(signal.SIGTERM, shutdown)


### PR DESCRIPTION
## Summary
- ensure the HTTP server shutdown is triggered from a background thread to avoid deadlocks when handling signals
- guard signal handling so shutdown logic only runs once

## Testing
- python -m compileall lywsd03mmc_passive_receiver.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c6990640832ea28c33ef0f09f46b